### PR TITLE
feat: add support to pass base64 objects to decoder

### DIFF
--- a/src/pdf-barcode.js
+++ b/src/pdf-barcode.js
@@ -164,12 +164,13 @@ var PDFBarcodeJs = (function () {
     }
 
     function getDocumentUrl(params) {
-        if (typeof window === 'undefined')
+        if (typeof window === 'undefined') {
             return params.input;
-        else if (typeof params.input === 'object' && params.input !== null)
+        } else if (typeof params.input === 'object' && params.input !== null && params.input.files !== undefined) {
             return URL.createObjectURL(params.input.files[0]);
-        else
+        } else {
             return params.input;
+        }
     }
 
     function setResult(result, document_barcode, currentPage, patch, scaled, settings) {

--- a/src/pdf-barcode.js
+++ b/src/pdf-barcode.js
@@ -163,6 +163,15 @@ var PDFBarcodeJs = (function () {
         return settings;
     }
 
+    function getDocumentUrl(params) {
+        if (typeof window === 'undefined')
+            return params.input;
+        else if (typeof params.input === 'object' && params.input !== null)
+            return URL.createObjectURL(params.input.files[0]);
+        else
+            return params.input;
+    }
+
     function setResult(result, document_barcode, currentPage, patch, scaled, settings) {
 
         if (settings.resultOpts.singleCodeInPage) { // when single result  quagga returns obj only
@@ -376,15 +385,8 @@ var PDFBarcodeJs = (function () {
         var currentPage = 1;
         var quagaconfigs = copyobj(settings.quagga);
 
-        var url = '';
-        if (typeof window === 'undefined')
-            url = params.input;
-        else if (typeof params.input === 'object' && params.input !== null)
-            url = URL.createObjectURL(params.input.files[0]);
-        else
-            url = params.input;
         PDFJS.disableWorker = true; // due to CORS
-        PDFJS.getDocument(url).promise.then(function (pdf) {
+        PDFJS.getDocument(getDocumentUrl(params)).promise.then(function (pdf) {
 
             if (params.singlePage) {
                 if (!pageInRange(pdf, params.pageNr)) {


### PR DESCRIPTION
Adding support to call the PDF Barcode library passing a Base64 file as expected by the PD JS core.