### PR TITLE
Add input key to result object

### DIFF
--- a/src/pdf-barcode.js
+++ b/src/pdf-barcode.js
@@ -328,6 +328,7 @@ var PDFBarcodeJs = (function () {
     function parseResult(result, params) {
 
         result.success = true;
+        result.input = params.input;
         if (params.singlePage) {
             delete result.codesByPage;
             delete result.statsByPage;


### PR DESCRIPTION
When running PDFBarcodeJS on multiple files concurrently and a callback occurs, there is no convenient way to identify which input source the result object applies to.  To solve this, a new key (input) is added to the result object based on the input value passed to PDFBarcodeJS's decode function when called.