### PR TITLE
Fixed warning message in console " failed to fetch font file" when used in node

### DIFF
--- a/src/pdf-barcode.js
+++ b/src/pdf-barcode.js
@@ -1,7 +1,8 @@
 var Quagga = require('quagga');
 Quagga = 'default' in Quagga ? Quagga['default'] : Quagga;
 var PDFJS = require("pdfjs-dist/legacy/build/pdf.js");
-const {createCanvas} = require('canvas')
+const {createCanvas} = require('canvas');
+var path = require('path');
 
 PDFJS.GlobalWorkerOptions.workerSrc = './pdf.worker.min.js';
 
@@ -387,7 +388,10 @@ var PDFBarcodeJs = (function () {
         var quagaconfigs = copyobj(settings.quagga);
 
         PDFJS.disableWorker = true; // due to CORS
-        PDFJS.getDocument(getDocumentUrl(params)).promise.then(function (pdf) {
+        PDFJS.getDocument({
+                url: getDocumentUrl(params),
+                standardFontDataUrl: path.join(__dirname, '../../node_modules/pdfjs-dist/standard_fonts/')
+            }).promise.then(function (pdf) {
 
             if (params.singlePage) {
                 if (!pageInRange(pdf, params.pageNr)) {


### PR DESCRIPTION
Fixed warning message in console below when used in node:

`Warning: fetchStandardFontData: failed to fetch file "FoxitSans.pfb" with "UnknownErrorException: The standard font "baseUrl" parameter must be specified, ensure that the "standardFontDataUrl" API parameter is provided.".`

`PDFBarcodeJS` must pass the `standardFontDataUrl` parameters with the path of the fonts when the `getDocument` method of the `pdfjs-dist` library is called. The `pdfjs-dist` library has a `standard_ fonts` folder that can be passed with the `standardFontDataUrl` parameter.